### PR TITLE
Update Dockerfile: fix typo in Github Action name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer="Shoukoo"
 LABEL version="0.2.0"
 LABEL repository="https://github.com/shoukoo/golang-pipeline"
 
-LABEL com.github.actions.name="Golang Pieline"
+LABEL com.github.actions.name="Golang Pipeline"
 LABEL com.github.actions.description="Introduction"
 LABEL com.github.actions.icon="box"
 LABEL com.github.actions.color="blue"


### PR DESCRIPTION
Just small fix to have the good name on the Github Marketplace