### PR TITLE
Ability to specify golint path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:latest
 
 LABEL name="Golang Pipeline"
 LABEL maintainer="Shoukoo"
-LABEL version="0.2.0"
+LABEL version="0.2.4"
 LABEL repository="https://github.com/shoukoo/golang-pipeline"
 
 LABEL com.github.actions.name="Golang Pipeline"

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ A program for checking for unchecked errors in go programs.
 Golint is more focused with coding style. Golint is in use at Google, and it seeks to match the accepted style of the open source Go project.
   - default: off
   - key: GOLINT
+
+  Additionally you can override default golint path with
+  - default: .
+  - key: GOLINTPATH
 - [**Misspell**](https://github.com/client9/misspell)
 Correct commonly misspelt English words
   - default : off
@@ -69,6 +73,7 @@ jobs:
       uses: shoukoo/golang-pipeline/go1.12/linter@master
       with:
         GOLINT: on
+        GOLINTPATH: pkg/controller
         MISSPELL: off
 ```
 ## Test:

--- a/go1.11/linter/Dockerfile
+++ b/go1.11/linter/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.11
 
 LABEL name="Golang Pipeline"
 LABEL maintainer="Shoukoo"
-LABEL version="0.2.0"
+LABEL version="0.2.4"
 LABEL repository="https://github.com/shoukoo/golang-pipeline"
 
 LABEL com.github.actions.name="Golang Pipeline"

--- a/go1.11/linter/gp-linter.sh
+++ b/go1.11/linter/gp-linter.sh
@@ -5,6 +5,7 @@ set -exuo pipefail
 STATICCHECK=${INPUT_STATICCHECK:-on}
 ERRCHECK=${INPUT_ERRCHECK:-on}
 GOLINT=${INPUT_GOLINT:-off}
+GOLINTPATH=${INPUT_GOLINTPATH:-.}
 MISSPELL=${INPUT_MISSPELL:-off}
 
 if [[ $STATICCHECK == "on" ]]; then
@@ -16,7 +17,7 @@ fi
 if [[ $GOLINT == "on" ]]; then
   # https://github.com/golang/lint
   go get -u golang.org/x/lint/golint
-  golint -set_exit_status=1 ./...
+  golint -set_exit_status=1 ${GOLINTPATH}/...
 fi
 
 if [[ $ERRCHECK == "on" ]]; then

--- a/go1.11/release/Dockerfile
+++ b/go1.11/release/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.11
 
 LABEL name="Golang Pipeline"
 LABEL maintainer="Shoukoo"
-LABEL version="0.2.0"
+LABEL version="0.2.4"
 LABEL repository="https://github.com/shoukoo/golang-pipeline"
 
 LABEL com.github.actions.name="Golang Pipeline"

--- a/go1.11/test/Dockerfile
+++ b/go1.11/test/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.11
 
 LABEL name="Golang Pipeline"
 LABEL maintainer="Shoukoo"
-LABEL version="0.2.0"
+LABEL version="0.2.4"
 LABEL repository="https://github.com/shoukoo/golang-pipeline"
 
 LABEL com.github.actions.name="Golang Pipeline"

--- a/go1.12/linter/Dockerfile
+++ b/go1.12/linter/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.12
 
 LABEL name="Golang Pipeline"
 LABEL maintainer="Shoukoo"
-LABEL version="0.2.0"
+LABEL version="0.2.4"
 LABEL repository="https://github.com/shoukoo/golang-pipeline"
 
 LABEL com.github.actions.name="Golang Pipeline"

--- a/go1.12/linter/gp-linter.sh
+++ b/go1.12/linter/gp-linter.sh
@@ -5,6 +5,7 @@ set -exuo pipefail
 STATICCHECK=${INPUT_STATICCHECK:-on}
 ERRCHECK=${INPUT_ERRCHECK:-on}
 GOLINT=${INPUT_GOLINT:-off}
+GOLINTPATH=${INPUT_GOLINTPATH:-.}
 MISSPELL=${INPUT_MISSPELL:-off}
 
 if [[ $STATICCHECK == "on" ]]; then
@@ -16,7 +17,7 @@ fi
 if [[ $GOLINT == "on" ]]; then
   # https://github.com/golang/lint
   go get -u golang.org/x/lint/golint
-  golint -set_exit_status=1 ./...
+  golint -set_exit_status=1 ${GOLINTPATH}/...
 fi
 
 if [[ $ERRCHECK == "on" ]]; then

--- a/go1.12/release/Dockerfile
+++ b/go1.12/release/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.12
 
 LABEL name="Golang Pipeline"
 LABEL maintainer="Shoukoo"
-LABEL version="0.2.0"
+LABEL version="0.2.4"
 LABEL repository="https://github.com/shoukoo/golang-pipeline"
 
 LABEL com.github.actions.name="Golang Pipeline"

--- a/go1.12/test/Dockerfile
+++ b/go1.12/test/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.12
 
 LABEL name="Golang Pipeline"
 LABEL maintainer="Shoukoo"
-LABEL version="0.2.0"
+LABEL version="0.2.4"
 LABEL repository="https://github.com/shoukoo/golang-pipeline"
 
 LABEL com.github.actions.name="Golang Pipeline"

--- a/go1.13/linter/Dockerfile
+++ b/go1.13/linter/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.13
 
 LABEL name="Golang Pipeline"
 LABEL maintainer="Shoukoo"
-LABEL version="0.2.0"
+LABEL version="0.2.4"
 LABEL repository="https://github.com/shoukoo/golang-pipeline"
 
 LABEL com.github.actions.name="Golang Pipeline"

--- a/go1.13/linter/gp-linter.sh
+++ b/go1.13/linter/gp-linter.sh
@@ -5,6 +5,7 @@ set -exuo pipefail
 STATICCHECK=${INPUT_STATICCHECK:-on}
 ERRCHECK=${INPUT_ERRCHECK:-on}
 GOLINT=${INPUT_GOLINT:-off}
+GOLINTPATH=${INPUT_GOLINTPATH:-.}
 MISSPELL=${INPUT_MISSPELL:-off}
 
 if [[ $STATICCHECK == "on" ]]; then
@@ -16,7 +17,7 @@ fi
 if [[ $GOLINT == "on" ]]; then
   # https://github.com/golang/lint
   go get -u golang.org/x/lint/golint
-  golint -set_exit_status=1 ./...
+  golint -set_exit_status=1 ${GOLINTPATH}/...
 fi
 
 if [[ $ERRCHECK == "on" ]]; then

--- a/go1.13/release/Dockerfile
+++ b/go1.13/release/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.13
 
 LABEL name="Golang Pipeline"
 LABEL maintainer="Shoukoo"
-LABEL version="0.2.0"
+LABEL version="0.2.4"
 LABEL repository="https://github.com/shoukoo/golang-pipeline"
 
 LABEL com.github.actions.name="Golang Pipeline"

--- a/go1.13/test/Dockerfile
+++ b/go1.13/test/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.13
 
 LABEL name="Golang Pipeline"
 LABEL maintainer="Shoukoo"
-LABEL version="0.2.0"
+LABEL version="0.2.4"
 LABEL repository="https://github.com/shoukoo/golang-pipeline"
 
 LABEL com.github.actions.name="Golang Pipeline"

--- a/linter.sh
+++ b/linter.sh
@@ -5,6 +5,7 @@ set -exuo pipefail
 STATICCHECK=${INPUT_STATICCHECK:-on}
 ERRCHECK=${INPUT_ERRCHECK:-on}
 GOLINT=${INPUT_GOLINT:-off}
+GOLINTPATH=${INPUT_GOLINTPATH:-.}
 MISSPELL=${INPUT_MISSPELL:-off}
 
 if [[ $STATICCHECK == "on" ]]; then
@@ -16,7 +17,7 @@ fi
 if [[ $GOLINT == "on" ]]; then
   # https://github.com/golang/lint
   go get -u golang.org/x/lint/golint
-  golint -set_exit_status=1 ./...
+  golint -set_exit_status=1 ${GOLINTPATH}/...
 fi
 
 if [[ $ERRCHECK == "on" ]]; then


### PR DESCRIPTION
Work the following way
```
    - name: go1.13  linters
      uses: AbsaOSS/golang-pipeline/go1.13/linter@master
      with:
        GOLINT: on
        GOLINTPATH: pkg/controller
```

Use case: point to the directory with code required to be inspected, e.g. skip `/vendor`  to avoid false positives